### PR TITLE
Support Taps in Hops

### DIFF
--- a/.hops.yml
+++ b/.hops.yml
@@ -1,15 +1,19 @@
 formulae:
-  - ansible
   - coreutils
-  - ffmpeg
   - fzf
-  - jq
+  - git
   - protobuf
   - s3cmd
   - starship
   - terraform
   - tree
   - wget
+taps:
+  - homebrew/bundle
+  - homebrew/cask
+  - homebrew/cask-drivers
+  - homebrew/cask-fonts
+  - homebrew/core
 casks:
   - 1password
   - anki
@@ -17,6 +21,7 @@ casks:
   - firefox-developer-edition
   - font-sauce-code-pro-nerd-font
   - google-chrome
+  - logitech-options
   - iterm2
   - keepingyouawake
   - postman
@@ -24,8 +29,6 @@ casks:
   - sequel-ace
   - slack
   - spotify
-  - todoist
   - tresorit
   - visual-studio-code
   - vlc
-  - zoom

--- a/internal/brew/commands.go
+++ b/internal/brew/commands.go
@@ -1,53 +1,78 @@
 package brew
 
+// AutoRemove uninstalls formulae that were only installed as a dependency of
+// another formula and are now no longer needed.
 func AutoRemove() ArgumentsOption {
 	return func() []string {
 		return []string{"autoremove"}
 	}
 }
 
+// Casks lists all locally installable casks including short names.
 func Casks() ArgumentsOption {
 	return func() []string {
 		return []string{"list", "--casks", "-1"}
 	}
 }
 
+// Cleanup removes stale lock files and outdated downloads for all formulae and
+// casks, and remove old versions of installed formulae.
 func Cleanup() ArgumentsOption {
 	return func() []string {
 		return []string{"cleanup"}
 	}
 }
 
+// Doctor checks your system for potential problems.
 func Doctor() ArgumentsOption {
 	return func() []string {
 		return []string{"doctor"}
 	}
 }
 
-func Install(packages []string) ArgumentsOption {
+// Install installs one or more formula or cask.
+func Install(packages []string, isCasks bool) ArgumentsOption {
 	return func() []string {
-		return append([]string{"install"}, packages...)
+		args := []string{"install"}
+		if isCasks {
+			args = append(args, "--casks")
+		}
+
+		return append(args, packages...)
 	}
 }
 
+// Leaves lists installed formulae that are not dependencies of another
+// installed formula.
 func Leaves() ArgumentsOption {
 	return func() []string {
-		return []string{"leaves"}
+		return []string{"leaves", "--installed-on-request"}
 	}
 }
 
+// Tap taps a formula repository.
+func Tap(name string) ArgumentsOption {
+	return func() []string {
+		return []string{"tap", name}
+	}
+}
+
+// Uninstall uninstalls one or more formula or cask.
 func Uninstall(packages []string) ArgumentsOption {
 	return func() []string {
 		return append([]string{"uninstall"}, packages...)
 	}
 }
 
+// Update fetches the newest version of Homebrew and all formulae from GitHub
+// using git and perform any necessary migrations.
 func Update() ArgumentsOption {
 	return func() []string {
 		return []string{"update", "--force"}
 	}
 }
 
+// Upgrade upgrades outdated casks and outdated, unpinned formulae.
 func Upgrade() ArgumentsOption {
 	return func() []string {
 		return []string{"upgrade"}

--- a/internal/brew/exec.go
+++ b/internal/brew/exec.go
@@ -9,9 +9,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type (
-	ArgumentsOption func() []string
-)
+// ArgumentsOption is a functional option for controlling what brew subcommand
+// is run for the Exec function.
+type ArgumentsOption func() []string
 
 // Exec allows for any Homebrew CLI command to be run, whilst either printing or
 // returning the output.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,10 +10,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Config holds the list of Homebrew packages (formulae and casks) to install
-// locally.
+// Config holds the list of Homebrew packages (formulae and casks) and taps to
+// install locally.
 type Config struct {
 	Formulae []string `yaml:"formulae"`
+	Taps     []string `yaml:"taps"`
 	Casks    []string `yaml:"casks"`
 }
 
@@ -44,20 +45,31 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("length of formulae list in config is zero")
 	}
 
+	if len(config.Taps) == 0 {
+		return Config{}, fmt.Errorf("length of taps list in config is zero")
+	}
+
 	if len(config.Casks) == 0 {
 		return Config{}, fmt.Errorf("length of casks list in config is zero")
 	}
 
 	config.Formulae = slice.Dedup(config.Formulae)
+	config.Taps = slice.Dedup(config.Taps)
 	config.Casks = slice.Dedup(config.Casks)
 
 	return config, nil
 }
 
+// Log outputs the contents of the config to the log.
 func (c Config) Log() {
 	log.Info().Msgf("%d formulae found in config", len(c.Formulae))
 	for _, f := range c.Formulae {
 		fmt.Printf(" %s\n", f) //nolint:forbidigo
+	}
+
+	log.Info().Msgf("%d taps found in config", len(c.Taps))
+	for _, t := range c.Taps {
+		fmt.Printf(" %s\n", t) //nolint:forbidigo
 	}
 
 	log.Info().Msgf("%d casks found in config", len(c.Casks))

--- a/main.go
+++ b/main.go
@@ -23,6 +23,12 @@ func main() { //nolint:cyclop,funlen
 	}
 	cfg.Log()
 
+	for _, tap := range cfg.Taps {
+		if _, err := brew.Exec(brew.Tap(tap)); err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	}
+
 	installedFormulae, err := brew.Exec(brew.Leaves())
 	if err != nil {
 		log.Fatal().Err(err).Send()
@@ -58,7 +64,7 @@ func main() { //nolint:cyclop,funlen
 		Msgf("%d formulae to install", len(formulaeToInstall))
 
 	if len(formulaeToInstall) > 0 {
-		if _, err := brew.Exec(brew.Install(formulaeToInstall)); err != nil {
+		if _, err := brew.Exec(brew.Install(formulaeToInstall, false)); err != nil {
 			log.Fatal().Err(err).Send()
 		}
 	}
@@ -68,7 +74,7 @@ func main() { //nolint:cyclop,funlen
 		Msgf("%d casks to install", len(casksToInstall))
 
 	if len(casksToInstall) > 0 {
-		if _, err := brew.Exec(brew.Install(casksToInstall)); err != nil {
+		if _, err := brew.Exec(brew.Install(casksToInstall, true)); err != nil {
 			log.Fatal().Err(err).Send()
 		}
 	}


### PR DESCRIPTION
- Lack of `brew tap` support makes the tool on new machines unusable 
- Remove some old packages that are no longer needed
- Add missing comments
- Add support for installing casks